### PR TITLE
Update ansible_install.sh to use https instead of git protocol

### DIFF
--- a/install_ansible.sh
+++ b/install_ansible.sh
@@ -7,7 +7,7 @@ mkdir -p $HOME/ansible_env
 cd $HOME/ansible_env
 virtualenv ansible
 source $HOME/ansible_env/ansible/bin/activate 
-git clone git://github.com/ansible/ansible.git --recursive ./ansible_source
+git clone https://github.com/ansible/ansible.git --recursive ./ansible_source
 #pexpect has to be 3.3 because new 4.01 version only
 # works with python >= 2.7 :(
 pip install paramiko PyYAML Jinja2 httplib2 six pexpect==3.3


### PR DESCRIPTION
Since most users won't be editing the Ansible repo, and since https protocol will go through firewalls more frequently than the git protocol.