### PR TITLE
Working around string/boolean warning for masquerade

### DIFF
--- a/roles/pre_ohpc/tasks/main.yml
+++ b/roles/pre_ohpc/tasks/main.yml
@@ -79,7 +79,7 @@
    - name: enable masquerade
      firewalld: 
        zone: public
-       masquerade: yes
+       masquerade: 'yes'
        permanent: yes
        state: enabled
      when: enable_compute_NAT == true


### PR DESCRIPTION
Root cause is logged at https://github.com/ansible/ansible/issues/54179 , but no idea when they'll get around to fixing it upstream. But since the `masquerade` parameter is documented as a string, we have to quote it as one to avoid the warning.