### PR TITLE
Making login and viz wwsh pxe updates match compute and gpu ones

### DIFF
--- a/roles/login_build_nodes/tasks/main.yml
+++ b/roles/login_build_nodes/tasks/main.yml
@@ -55,4 +55,4 @@
    - name: wwsh pxe update
      command: wwsh -v pxe update
      register: command_result
-     failed_when: "'Building Pxelinux' not in command_result.stdout"
+     failed_when: "'Building iPXE' not in command_result.stdout and 'Building Pxelinux' not in command_result.stdout"

--- a/roles/viz_build_nodes/tasks/main.yml
+++ b/roles/viz_build_nodes/tasks/main.yml
@@ -55,4 +55,4 @@
    - name: wwsh pxe update
      command: wwsh -v pxe update
      register: command_result
-     failed_when: "'Building Pxelinux' not in command_result.stdout"
+     failed_when: "'Building iPXE' not in command_result.stdout and 'Building Pxelinux' not in command_result.stdout"


### PR DESCRIPTION
`wwsh pxe update` had some changes to its command output that were working correctly in the compute and gpu roles, but not in the login or viz roles. Updating the login and viz roles to match.