### PR TITLE
Create .gitignore to exclude site-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /host_vars/
 # Ignore site-specific Nvidia/CUDA installers
 /roles/gpu_build_vnfs/files/*.run
+# Leave original Nvidia installer intact
+!/roles/gpu_build_vnfs/files/NVIDIA-Linux-x86_64-375.39.run

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Allow site-specific ansible host_vars, keeping group_vars/all as the defaults
+/host_vars/
+# Ignore site-specific Nvidia/CUDA installers
+/roles/gpu_build_vnfs/files/*.run


### PR DESCRIPTION
Allows sites to have host_vars for local settings, while keeping group_vars/all for defaults. Also excludes local copies of Nvidia/CUDA installers.