### PR TITLE
Fix yum warnings

### DIFF
--- a/roles/compute_build_vnfs/tasks/main.yml
+++ b/roles/compute_build_vnfs/tasks/main.yml
@@ -43,7 +43,18 @@
      copy: src=/etc/resolv.conf dest="{{ compute_chroot_loc }}/etc/resolv.conf" #"
 
    - name: yum install into the image chroot
-     command: yum -y --installroot={{ compute_chroot_loc }} install chrony kernel lmod-ohpc grub2 freeipmi ipmitool ohpc-slurm-client 
+     yum:
+       name: "{{ packages }}"
+       installroot: "{{ compute_chroot_loc }}"
+     vars:
+       packages:
+         - chrony
+         - kernel
+         - lmod-ohpc
+         - grub2
+         - freeipmi
+         - ipmitool
+         - ohpc-slurm-client
 #" for vim
 
    - name: copy ssh keys over

--- a/roles/gpu_build_vnfs/tasks/main.yml
+++ b/roles/gpu_build_vnfs/tasks/main.yml
@@ -13,11 +13,23 @@
      copy: src=/etc/resolv.conf dest="{{ gpu_chroot_loc }}/etc/resolv.conf" #"
 
    - name: yum install into the image chroot
-     command: yum -y --installroot={{ gpu_chroot_loc }} install chrony kernel lmod-ohpc grub2 glibc-devel glibc-headers kernel-devel kernel-headers dkms gcc
+     yum:
+       packages: "{{ packages }}"
+       installroot:  "{{ gpu_chroot_loc }}"
+     vars:
+       packages:
+         - chrony
+         - kernel
+         - lmod-ohpc
+         - grub2
+         - glibc-devel
+         - glibc-headers
+         - kernel-devel
+         - kernel-headers
+         - dkms
+         - gcc
+         - ohpc-slurm-client
 #" for vim
-
-   - name: yum install slurm client into image
-     command: yum -y --installroot={{ gpu_chroot_loc }} groupinstall ohpc-slurm-client
 
    - name: create export dir
      file: path="{{ gpu_chroot_loc }}/export" state=directory

--- a/roles/gpu_build_vnfs/tasks/main.yml
+++ b/roles/gpu_build_vnfs/tasks/main.yml
@@ -14,7 +14,7 @@
 
    - name: yum install into the image chroot
      yum:
-       packages: "{{ packages }}"
+       name: "{{ packages }}"
        installroot:  "{{ gpu_chroot_loc }}"
      vars:
        packages:

--- a/roles/login_build_vnfs/tasks/main.yml
+++ b/roles/login_build_vnfs/tasks/main.yml
@@ -13,11 +13,23 @@
      copy: src=/etc/resolv.conf dest="{{ login_chroot_loc }}/etc/resolv.conf" #"
 
    - name: yum install into the image chroot
-     command: yum -y --installroot={{ login_chroot_loc }} install chrony kernel lmod-ohpc grub2 glibc-devel glibc-headers kernel-devel kernel-headers dkms
+     yum:
+       packages: "{{ packages }}"
+       installroot: "{{ login_chroot_loc }}"
+     vars:
+       packages:
+         - chrony
+         - kernel
+         - lmod-ohpc
+         - grub2
+         - glibc-devel
+         - glibc-headers
+         - kernel-devel
+         - kernel-headers
+         - dkms
+         - ohpc-slurm-client
 #" for vim
 
-   - name: yum install slurm client into image
-     command: yum -y --installroot={{ login_chroot_loc }} groupinstall ohpc-slurm-client
 #" for vim
 #
 ##FIREWALL STUFF - DON'T LEAVE COMMENTED OUT

--- a/roles/login_build_vnfs/tasks/main.yml
+++ b/roles/login_build_vnfs/tasks/main.yml
@@ -14,7 +14,7 @@
 
    - name: yum install into the image chroot
      yum:
-       packages: "{{ packages }}"
+       name: "{{ packages }}"
        installroot: "{{ login_chroot_loc }}"
      vars:
        packages:


### PR DESCRIPTION
The `yum` module supports an `installroot` parameter, so no need to call `yum` through the `command` module.