### PR TITLE
Feature consolidate build nodes

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -100,5 +100,7 @@
 # Don't edit these!
   compute_node_glob: "{{ compute_node_prefix }}[0-{{ num_compute_nodes|int - 1}}]"
   gpu_node_glob: "{{ gpu_node_prefix }}[0-{{ num_gpu_nodes|int - 1}}]"
-  node_glob_bash: "{{ compute_node_prefix }}{0..{{ num_compute_nodes|int - 1}}}"
+  compute_node_glob_bash: "{{ compute_node_prefix }}{0..{{ num_compute_nodes|int - 1}}}"
   gpu_node_glob_bash: "{{ gpu_node_prefix }}{0..{{ num_gpu_nodes|int - 1}}}"
+  # to be deprecated:
+  node_glob_bash: "{{ compute_node_prefix }}{0..{{ num_compute_nodes|int - 1}}}"

--- a/headnode.yml
+++ b/headnode.yml
@@ -8,8 +8,30 @@
    - {role: compute_build_vnfs, tags: compute_build_vnfs}
    - {role: gpu_build_vnfs, tags: gpu_build_vnfs}
    - {role: login_build_vnfs, tags: login_build_vnfs}
-   - {role: compute_build_nodes, tags: compute_build_nodes}
-   - {role: gpu_build_nodes, tags: gpu_build_nodes}
-   - {role: login_build_nodes, tags: login_build_nodes}
-   - {role: viz_build_nodes, tags: viz_build_nodes}
+   # By default, compute and gpu nodes use an automatic inventory with a
+   # group of ansible string vars to define their chroots, names, ips, etc.
+   - { role: build_nodes,
+       node_glob: "{{ compute_node_glob }}",
+       node_glob_bash: "{{ compute_node_glob_bash }}",
+       node_inventory_auto: true,
+       ip_minimum: "{{ compute_ip_minimum }}",
+       chroot: "{{ compute_chroot }}",
+       tags: compute_build_nodes }
+   - { role: build_nodes,
+       node_glob: "{{ gpu_node_glob }}",
+       node_glob_bash: "{{ gpu_node_glob_bash }}",
+       node_inventory_auto: true,
+       ip_minimum: "{{ gpu_ip_minimum }}",
+       chroot: "{{ gpu_chroot }}",
+       tags: gpu_build_nodes }
+   # By default, login and viz nodes use a manual inventory with an ansible
+   # list of dicts to define their chroots, names, ips, etc.
+   - { role: build_nodes,
+       nodes: "{{ login_nodes }}",
+       node_inventory_auto: false,
+       tags: login_build_nodes }
+   - { role: build_nodes,
+       nodes: "{{ viz_nodes }}",
+       node_inventory_auto: false,
+       tags: viz_build_nodes }
    - {role: nodes_vivify, tags: nodes_vivify}

--- a/roles/build_nodes/tasks/list_and_add.yml
+++ b/roles/build_nodes/tasks/list_and_add.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Check if node exists
+  command: wwsh node list {{ item.name }}
+  register: wwsh_node_list
+  changed_when: no
+  failed_when: no
+#- name: Show output
+#  debug:
+#    msg: "{{ wwsh_node_list }}"
+- name: Add missing node
+  command: wwsh -y node new {{ item.name }} --ipaddr={{ item.ip }} --hwaddr={{ item.mac }} -D {{ compute_private_nic }}
+  when: wwsh_node_list.rc != 0

--- a/roles/build_nodes/tasks/main.yml
+++ b/roles/build_nodes/tasks/main.yml
@@ -59,7 +59,7 @@
      when: node_inventory_auto == false
 
    - block:
-     - name: add nodes via wwnodescan
+     - name: add nodes via wwnodescan - BOOT NODES {{ node_glob }} NOW, IN ORDER
        shell: wwnodescan --listen={{ private_interface }} --ip={{ ip_minimum }} --netdev={{ compute_private_nic }} --netmask={{ private_network_long_netmask }} --bootstrap={{ build_kernel_ver }} --vnfs={{ chroot }} {{ node_glob_bash }}
 
      - name: set node glob gateway in ww db

--- a/roles/build_nodes/tasks/main.yml
+++ b/roles/build_nodes/tasks/main.yml
@@ -16,7 +16,8 @@
        when: stateful_nodes == true
 
      - name: update pxeconfig to force node to boot from pxe
-       command: wwsh -y object modify -D bootlocal -t node {{ node_glob}}
+       command: wwsh -y object modify -D bootlocal -t node {{ item.name }}
+       with_items: "{{ nodes }}"
        when: stateful_nodes == false
 
      - name: set files to provision

--- a/roles/build_nodes/tasks/main.yml
+++ b/roles/build_nodes/tasks/main.yml
@@ -1,0 +1,104 @@
+---
+   - block:
+
+     - name: add node to ww db
+       include_tasks: list_and_add.yml
+       with_items: "{{ nodes }}"
+
+     - name: set node gateway in ww db
+       command: wwsh -y node set {{ item.name }} --gateway={{ headnode_private_ip }} -D {{ compute_private_nic }}
+       with_items: "{{ nodes }}"
+       when: enable_compute_NAT == true
+
+     - name: provision stateful node
+       include_tasks: provision_stateful_node.yml
+       with_items: "{{ nodes }}"
+       when: stateful_nodes == true
+
+     - name: update pxeconfig to force node to boot from pxe
+       command: wwsh -y object modify -D bootlocal -t node {{ compute_node_glob}}
+       when: stateful_nodes == false
+
+     - name: set files to provision
+       command: wwsh -y provision set {{ item.name }} --vnfs={{ item.vnfs }} --bootstrap={{ build_kernel_ver }} --files={{ base_provision_files }}
+     - name: add Active Directory files to provision
+       command: wwsh -y provision set {{ item.name }} --fileadd={{ ad_provision_files }}
+       with_items: "{{ nodes }}"
+       when: enable_active_directory == true
+
+     - name: remove node from slurm.conf if it exists already
+       lineinfile:
+         dest: /etc/slurm/slurm.conf
+         regexp: "^NodeName={{ item.name }} "
+         state: absent
+       with_items: "{{ nodes }}"
+     - name: add node to slurm.conf
+       lineinfile:
+         dest: /etc/slurm/slurm.conf
+         line: "NodeName={{ item.name }} Sockets={{ item.sockets }} CoresPerSocket={{ item.corespersocket }}{% if item.gpu_type is defined %} Gres=gpu:{{ item.gpu_type }}:{{ item.gpus }}{% endif %} State=UNKNOWN"
+         insertbefore: "^# PARTITIONS"
+         state: present
+       with_items: "{{ nodes }}"
+
+     - block:
+       - name: remove node from gres.conf if it exists already
+         lineinfile:
+           dest: /etc/slurm/gres.conf
+           regexp: "^NodeName={{ item.name }} "
+           state: absent
+       - name: add node info to slurm/gres.conf
+         lineinfile:
+           dest: /etc/slurm/gres.conf
+           line: "NodeName={{ item.name }} Name=gpu Type={{ item.gpu_type }} File=/dev/nvidia[0-{{ item.gpus - 1 }}]"
+           insertafter: "^#######"
+           state: present
+       - name: blacklist nouveau on first boot
+         command: wwsh -y object modify -s kargs='modprobe.blacklist=nouveau,quiet' -t node {{ item.name }}
+       when: item.gpu_type is defined
+       with_items: "{{ nodes }}"
+
+     when: node_inventory_auto == false
+
+   - block:
+     - name: add nodes via wwnodescan # this seemed to be the same command regardless of NAT, and NAT may be handled with wwsh node set --gateway instead
+       shell: wwnodescan --listen={{ private_interface }} --ip={{ compute_ip_minimum }} --netdev={{ compute_private_nic }} --netmask={{ private_network_long_netmask }} --bootstrap={{ build_kernel_ver }} --vnfs={{ compute_chroot }} {{ node_glob_bash }}
+
+     - name: set node glob gateway in ww db
+       command: wwsh -y node set --gateway={{ headnode_private_ip }} -D {{ compute_private_nic }} {{ node_glob }} 
+       when: enable_compute_NAT == true
+
+     - name: provision stateful node glob
+       include_tasks: provision_stateful_node.yml
+       with_items: 
+           - "{ name: {{ node_glob }} }"
+       when: stateful_nodes == true
+
+     - name: update pxeconfig to force node glob to boot from pxe
+       command: wwsh -y object modify -D bootlocal -t node {{ node_glob }}
+       when: stateful_nodes == false
+
+     - name: set files to provision for node glob
+       command: wwsh -y provision set --vnfs={{ chroot }} --bootstrap={{ build_kernel_ver }} --files={{ base_provision_files }} {{ node_glob }}
+     - name: add Active Directory files to provision for node glob
+       command: wwsh -y provision set --fileadd={{ ad_provision_files }} {{ node_glob }}
+       when: enable_active_directory == true
+
+     # need blacklist nouveau
+
+     when: node_inventory_auto == true
+
+   - name: wwsh file sync
+     command: wwsh file sync
+
+   - name: restart dhcp if required
+     service: name=dhcpd state=restarted enabled=yes
+     when: dhcpd_enabled == true
+
+   - name: disable dhcp if required
+     service: name=dhcpd state=stopped enabled=no
+     when: dhcpd_enabled == false
+
+   - name: wwsh pxe update
+     command: wwsh -v pxe update
+     register: command_result
+     failed_when: "'Building iPXE' not in command_result.stdout and 'Building Pxelinux' not in command_result.stdout"

--- a/roles/build_nodes/tasks/main.yml
+++ b/roles/build_nodes/tasks/main.yml
@@ -22,6 +22,7 @@
 
      - name: set files to provision
        command: wwsh -y provision set {{ item.name }} --vnfs={{ item.vnfs }} --bootstrap={{ build_kernel_ver }} --files={{ base_provision_files }}
+       with_items: "{{ nodes }}"
      - name: add Active Directory files to provision
        command: wwsh -y provision set {{ item.name }} --fileadd={{ ad_provision_files }}
        with_items: "{{ nodes }}"

--- a/roles/build_nodes/tasks/main.yml
+++ b/roles/build_nodes/tasks/main.yml
@@ -52,8 +52,6 @@
            line: "NodeName={{ item.name }} Name=gpu Type={{ item.gpu_type }} File=/dev/nvidia[0-{{ item.gpus - 1 }}]"
            insertafter: "^#######"
            state: present
-       - name: blacklist nouveau on first boot
-         command: wwsh -y object modify -s kargs='modprobe.blacklist=nouveau,quiet' -t node {{ item.name }}
        when: item.gpu_type is defined
        with_items: "{{ nodes }}"
 
@@ -82,8 +80,6 @@
      - name: add Active Directory files to provision for node glob
        command: wwsh -y provision set --fileadd={{ ad_provision_files }} {{ node_glob }}
        when: enable_active_directory == true
-
-     # need blacklist nouveau
 
      when: node_inventory_auto == true
 

--- a/roles/build_nodes/tasks/main.yml
+++ b/roles/build_nodes/tasks/main.yml
@@ -16,7 +16,7 @@
        when: stateful_nodes == true
 
      - name: update pxeconfig to force node to boot from pxe
-       command: wwsh -y object modify -D bootlocal -t node {{ compute_node_glob}}
+       command: wwsh -y object modify -D bootlocal -t node {{ node_glob}}
        when: stateful_nodes == false
 
      - name: set files to provision
@@ -41,25 +41,26 @@
        with_items: "{{ nodes }}"
 
      - block:
-       - name: remove node from gres.conf if it exists already
+       - name: remove gpu node from gres.conf if it exists already
          lineinfile:
            dest: /etc/slurm/gres.conf
            regexp: "^NodeName={{ item.name }} "
            state: absent
-       - name: add node info to slurm/gres.conf
+         with_items: "{{ nodes }}"
+       - name: add gpu node info to slurm/gres.conf
          lineinfile:
            dest: /etc/slurm/gres.conf
            line: "NodeName={{ item.name }} Name=gpu Type={{ item.gpu_type }} File=/dev/nvidia[0-{{ item.gpus - 1 }}]"
            insertafter: "^#######"
            state: present
+         with_items: "{{ nodes }}"
        when: item.gpu_type is defined
-       with_items: "{{ nodes }}"
 
      when: node_inventory_auto == false
 
    - block:
-     - name: add nodes via wwnodescan # this seemed to be the same command regardless of NAT, and NAT may be handled with wwsh node set --gateway instead
-       shell: wwnodescan --listen={{ private_interface }} --ip={{ compute_ip_minimum }} --netdev={{ compute_private_nic }} --netmask={{ private_network_long_netmask }} --bootstrap={{ build_kernel_ver }} --vnfs={{ compute_chroot }} {{ node_glob_bash }}
+     - name: add nodes via wwnodescan
+       shell: wwnodescan --listen={{ private_interface }} --ip={{ ip_minimum }} --netdev={{ compute_private_nic }} --netmask={{ private_network_long_netmask }} --bootstrap={{ build_kernel_ver }} --vnfs={{ chroot }} {{ node_glob_bash }}
 
      - name: set node glob gateway in ww db
        command: wwsh -y node set --gateway={{ headnode_private_ip }} -D {{ compute_private_nic }} {{ node_glob }} 

--- a/roles/build_nodes/tasks/provision_stateful_node.yml
+++ b/roles/build_nodes/tasks/provision_stateful_node.yml
@@ -1,0 +1,12 @@
+---
+
+- name: set node bootloader
+  command: wwsh -y object modify -s bootloader=sda -t node {{ item.name }}
+- name: set node partitions
+  command: wwsh -y object modify -s diskpartition=sda -t node {{ item.name }}
+- name: format partitions
+  command: wwsh -y object modify -s diskformat=sda1,sda2,sda3 -t node {{ item.name }}
+- name: define filesystems
+  command: wwsh -y object modify -s filesystems="{{ sda1 }},{{ sda2 }},{{ sda3 }}" -t node {{ item.name }}
+- name: update pxeconfig to let node boot from local disk
+  command: wwsh -y object modify -s bootlocal=EXIT -t node {{ item.name }}

--- a/roles/build_nodes/vars/main.yml
+++ b/roles/build_nodes/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+base_provision_files: passwd,group,shadow,munge.key,slurm.conf,dynamic_hosts,network
+ad_provision_files: krb5.keytab,krb5.conf,sssd.conf


### PR DESCRIPTION
This is the big one, and there may be a consolidated build_vnfs role coming later.

Have tested this on an environment where the compute and gpu nodes were created with `node_inventory_auto: true` and `wwnodescan`, and the login and viz nodes were created with `node_inventory_auto: false`, which matches the default behavior from before (since the existing `login_` and `viz_build_nodes` roles never used `wwnodescan`).

It might be best to move the `node_inventory_auto` variable out of `group_vars/all` entirely, since it didn't really apply to all four node building roles.

Also added a more descriptive title to the `wwnodescan` task, for example:

```
TASK [build_nodes : add nodes via wwnodescan - BOOT NODES compute-[0-1] NOW, IN ORDER] ***
```

Have not yet tested with stateful nodes, but there shouldn't be any breaking changes there.

I'd also like to verify if login nodes need to NAT through the SMS node like the compute nodes do. I suspect they shouldn't, but they'd also need a second NIC that's external facing. That should easily be handled by an additional `enable_NAT` variable set for each node type: `true` for compute and GPU nodes, `false` for login nodes, and either for viz nodes (depending on if they're more like GPU nodes or login nodes).

May also want something in the documentation about manually editing `slurm.conf` and `gres.conf` when `node_inventory_auto` is true.

When ready to merge, should squash all these down into a single commit. Removing the old node-building roles can come later.