### PR TITLE
Fixes wwinit ssh creates With Different File Check

### DIFF
--- a/roles/ohpc_config/tasks/main.yml
+++ b/roles/ohpc_config/tasks/main.yml
@@ -59,7 +59,7 @@
      command: wwinit ssh_keys
      args:
        chdir: /root/
-       creates: /etc/warewulf/vnfs/ssh/ssh_host_key.pub
+       creates: /etc/warewulf/vnfs/ssh/ssh_host_rsa_key.pub
 
 #need to copy these to localhost first!
    - name: copy key back to management machine


### PR DESCRIPTION
The ssh_host_key.pub is a file that is not created by wwinit ssh.
This causes a crash when the playbook is rerun. This is fixed by changing ssh_host_key.pub to a file created by wwinit ssh, ssh_host_rsa_key.pub being one working example.