### PR TITLE
Updates nic Variables Docs to Properly Explain Usage

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -150,7 +150,7 @@ For the device of the host-only network, it will be referred to as ```$host-nic`
 Save the ip address of the interface on the host-only network - 
 you'll use this as the address for the headnode in the ansible scripts.
 
-The device for the Internal Network will be referred to as ```$internal-nic```. The
+The device for the internal network will be referred to as ```$internal-nic```. The
 IP address created earlier will be relevant throughout this documentation.
 
 Make sure that the host-only and internal adapters are not set as default

--- a/doc/README.md
+++ b/doc/README.md
@@ -142,16 +142,16 @@ in Virtualbox, to be sure you substitute the correct device names below!
 (Typically, they show up as something like enp0s3,enp0s8, etc. - it pays to
 double-check!)
 
-The NAT ip address will be used sparingly in the following documentation, but will
-be called ```$public-nic```. Virtualbox assigns these as 10.0.x.15, where x begins
-at 2 for the 1st VM, 3 for the 2nd, etc.
+The NAT device, along with its IP, will be used sparingly in the following documentation, 
+but will be called ```$public-nic```. Virtualbox assigns the IP address as 10.0.x.15,
+where x begins at 2 for the 1st VM, 3 for the 2nd, etc.
 
+For the device of the host-only network, it will be referred to as ```$host-nic```.
 Save the ip address of the interface on the host-only network - 
-you'll use this as the address for the headnode in the ansible scripts, 
-and it will be referred to as ```$host-nic```
+you'll use this as the address for the headnode in the ansible scripts.
 
-The ip address for the internal nic was set earlier, and will be referred to 
-either as 10.0.0.1 or ```$internal-nic```
+The device for the Internal Network will be referred to as ```$internal-nic```. The
+IP address created earlier will be relevant throughout this documentation.
 
 Make sure that the host-only and internal adapters are not set as default
 routes - ```ip route show``` should not list them as default! 


### PR DESCRIPTION
The nic variables are mislabeled as stand-ins for the IPs of the network devices, and then, they are immediately used where a device name is required instead.
This could confuse a user in the case that they do not know the nmcli commands, so the documentation has been changed to say instead that they are stand-ins for device names rather than IPs.