### PR TITLE
Change the Ansible Inventory Section to more clearly state what to change.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -415,7 +415,7 @@ Note the inventory file in
 headnode ansible_host="{{ headnode_private_ip }}" ansible_connection=ssh ansible_ssh_user=root
 ```
 
-Make sure that the hostname of your headnode matches the entry on that line! Either
+Make sure that the hostname of your headnode matches the entry on that second line! Either
 edit the inventory file, or change the hostname via:
 ```hostnamectl set-hostname headnode```.
 


### PR DESCRIPTION
The original version has two instances of "headnode" that can be changed, but the user must only change the one if they do not want to name their machine headnode. 
Before, this could have lead to some minor time debugging and confusion. Therefore, a small change was made to help clarify which "headnode" to change.  